### PR TITLE
PR作成時にClaude Codeレビューを自動実行するワークフローを追加

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,41 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            このリポジトリは Zenn 公開用の技術記事リポジトリです。
+            CLAUDE.md のルール（一次ソース検証、引用は WebFetch で確認、重複防止 など）に沿ってレビューしてください。
+
+            主なレビュー観点：
+            - 事実誤認・誤った引用がないか（特に `> 引用` 形式の文言）
+            - コマンド名・API名・プラグイン名が現行の公式仕様と一致しているか
+            - 既存記事との重複や、`articles/` 配下の Front Matter（title / emoji / type / topics / published）の妥当性
+            - 日本語表現の自然さ（です・ます調の統一、冗長な言い回しの整理）
+            - リンク切れや相対リンクの誤り
+
+            指摘は `mcp__github_inline_comment__create_inline_comment`（`confirmed: true`）でインラインコメントを優先し、
+            総評は `gh pr comment` で投稿してください。チャットへの出力ではなく GitHub 上にコメントを残すことが目的です。
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- `.github/workflows/claude-review.yml` を追加し、PR の `opened` / `synchronize` / `ready_for_review` / `reopened` で `anthropics/claude-code-action@v1` を起動
- 認証は Claude Pro/Max のサブスクリプション（`CLAUDE_CODE_OAUTH_TOKEN`）を利用
- Zenn 記事リポジトリの CLAUDE.md ルール（一次ソース検証、引用は WebFetch で確認、Front Matter チェック等）に沿ったレビュー観点をプロンプトに記述

## 事前準備（マージ前に必要）
- [ ] ローカルで `claude setup-token` を実行し、OAuth トークンを発行
- [ ] リポジトリの Settings → Secrets and variables → Actions に `CLAUDE_CODE_OAUTH_TOKEN` を登録
- [ ] Claude GitHub App をリポジトリにインストール（未導入の場合は `/install-github-app`）

## Test plan
- [ ] このPR自体でワークフローが起動し、Claudeがレビューコメントを投稿することを確認
- [ ] インラインコメント（mcp__github_inline_comment__create_inline_comment）と総評コメント（gh pr comment）の両方が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated pull request review workflow using Claude-powered code analysis, providing comprehensive quality checks including fact verification, citation validation, API/command specification accuracy, content structure correctness, and writing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->