### PR TITLE
記事: Chrome組み込みAIの実測 2本

### DIFF
--- a/articles/2026-08-11-chrome-builtin-ai-benchmark.md
+++ b/articles/2026-08-11-chrome-builtin-ai-benchmark.md
@@ -1,0 +1,263 @@
+---
+title: "Chromeの組み込みAIを実測したら、速いのはLLMじゃない方だった"
+emoji: "⚡"
+type: "tech"
+topics: ["chrome", "javascript", "ai", "webapi", "frontend"]
+published: true
+---
+
+## はじめに
+
+ブラウザに AI が組み込まれる、という話題では Prompt API（Gemini Nano）ばかりが注目されます。任意のプロンプトを投げられるので、たしかに一番派手です。
+
+ただ、実際に自分のマシンで全部のAPIを叩いて時間を測ってみたところ、評価が逆転しました。**実用速度で圧倒的に優れていたのは、LLMではない専用APIの方**でした。
+
+この記事では Chrome 150 上で組み込みAI各APIの可用性とレイテンシを実測し、どのAPIをどう選ぶべきかを整理します。すべて手元で再現できるコードを載せています。
+
+## 検証環境
+
+| 項目 | 値 |
+|---|---|
+| ブラウザ | Chrome 150.0.0.0 |
+| OS | macOS |
+| 計測方法 | `performance.now()` の差分、各3回 |
+
+Chrome の[公式ドキュメント](https://developer.chrome.com/docs/ai/prompt-api)によると、組み込みAIの利用には空きストレージ22GB、GPUのVRAM 4GB以上またはCPU 16GB RAM以上・4コア以上が必要とされています。要件を満たさない環境では以降のコードが `unavailable` を返します。
+
+## まず可用性を調べる
+
+各APIはグローバルオブジェクトとして生えています。存在確認と `availability()` を一気に回します。
+
+```js
+const names = [
+  'LanguageModel', 'Translator', 'LanguageDetector',
+  'Summarizer', 'Writer', 'Rewriter', 'Proofreader',
+];
+
+for (const n of names) {
+  if (!(n in self)) {
+    console.log(n, 'グローバルなし');
+    continue;
+  }
+  try {
+    console.log(n, await self[n].availability({}));
+  } catch (e) {
+    console.log(n, `ERR ${e.name}: ${e.message}`);
+  }
+}
+```
+
+手元の Chrome 150 での結果です。
+
+| API | 結果 |
+|---|---|
+| `LanguageDetector` | `available` |
+| `Translator` | 引数必須のため `TypeError`（後述） |
+| `Summarizer` | `downloadable` |
+| `LanguageModel` | `downloadable` |
+| `Writer` | グローバルなし |
+| `Rewriter` | グローバルなし |
+| `Proofreader` | グローバルなし |
+
+いきなり3つ躓きました。
+
+Chrome の[ドキュメント](https://developer.chrome.com/docs/ai/built-in-apis)上では Writer / Rewriter / Proofreader は origin trial 段階とされていますが、トライアルに登録していない状態では**グローバルすら生えていません**。`'Writer' in self` が `false` なので、機能検出は素直に書けば足ります。
+
+`Translator.availability({})` は空オブジェクトだと落ちます。
+
+```
+TypeError: Failed to execute 'availability' on 'Translator':
+Failed to read the 'sourceLanguage' property from 'TranslatorCreateCoreOptions':
+Required member is undefined.
+```
+
+翻訳は言語ペアごとにモデルが違うので、可用性の判定にも言語指定が要る、という設計です。他のAPIと引数の扱いが揃っていないので、共通ループで回すときは個別対応が必要になります。
+
+```js
+await Translator.availability({ sourceLanguage: 'en', targetLanguage: 'ja' });
+// → 'available'
+```
+
+## 実測① LanguageDetector — ほぼコストゼロ
+
+言語判定から測ります。
+
+```js
+const t0 = performance.now();
+const detector = await LanguageDetector.create();
+console.log('create:', Math.round(performance.now() - t0), 'ms');
+
+for (const s of samples) {
+  const t = performance.now();
+  const r = await detector.detect(s);
+  console.log(Math.round(performance.now() - t), 'ms', r[0].detectedLanguage, r[0].confidence);
+}
+```
+
+結果です。
+
+| 処理 | 時間 |
+|---|---|
+| `create()` | **2ms** |
+| 英文93文字の判定 | **1ms**（`en` 100.0%） |
+| 和文27文字の判定 | **1ms**（`ja` 99.7%） |
+| コード片の判定 | **0ms**（`en` 99.9%） |
+
+`create()` が2ms、判定が0〜1msです。これは実質コストゼロで、UIのイベントハンドラ内で同期的に呼んでも問題にならない水準です。
+
+`detect()` は候補の配列を信頼度つきで返します。判定できないときは `und`（undetermined）が返るので、閾値を決めて切り捨てる運用になります。
+
+## 実測② Translator — 90文字を26〜44ms
+
+翻訳です。en→ja のモデルはすでに `available` でした。
+
+```js
+const t0 = performance.now();
+const translator = await Translator.create({
+  sourceLanguage: 'en',
+  targetLanguage: 'ja',
+  monitor(m) {
+    m.addEventListener('downloadprogress', (e) => {
+      console.log(`Downloaded ${(e.loaded * 100).toFixed(1)}%`);
+    });
+  },
+});
+console.log('create:', Math.round(performance.now() - t0), 'ms');
+
+const t = performance.now();
+const out = await translator.translate(text);
+console.log(Math.round(performance.now() - t), 'ms', out);
+```
+
+| 処理 | 時間 |
+|---|---|
+| `create()` | **109ms** |
+| 93文字の翻訳 | **44ms** |
+| 92文字の翻訳 | **26ms** |
+| ウォーム後の短文（`Hello world.`） | **8ms** |
+
+訳文も実物を載せます。入力と出力は次の通りです。
+
+入力:
+
+```
+Anchor positioning is a new layout mechanism for anchoring one element to another on the web.
+```
+
+出力:
+
+```
+アンカー ポジショニングは、Web 上で要素を別の要素に固定するための新しいレイアウト メカニズムです。
+```
+
+用語がカタカナで分かち書きされる癖はありますが、意味は正確です。**90文字前後で26〜44ms、ウォーム後の短文なら8ms**というのは、入力中のリアルタイム翻訳にも耐える速度です。
+
+なお `create()` の109msは、初回のみ発生するセッション構築コストです。翻訳のたびに `create()` を呼ぶと毎回これが乗るので、言語ペアごとにインスタンスを保持するのが正解になります。
+
+## 実測③ Prompt API と比べる
+
+ここからが本題です。同じ「文章を生成する」処理を Prompt API（Gemini Nano）でやらせて比較します。
+
+Prompt API は `downloadable` 状態だったので、まずモデルを落とす必要がありました。この初回ダウンロードは**ユーザー操作が必須**で、DevTools のコンソールから直接は開始できません。ボタンのクリックハンドラ内で `create()` を呼ぶ必要があります。
+
+```html
+<button id="prep">モデルを準備する</button>
+<script>
+document.querySelector('#prep').addEventListener('click', async () => {
+  const session = await LanguageModel.create({
+    monitor(m) {
+      m.addEventListener('downloadprogress', (e) => {
+        console.log(`${(e.loaded * 100).toFixed(1)}%`);
+      });
+    },
+  });
+  session.destroy();
+});
+</script>
+```
+
+手元では数GB規模のダウンロードに数分かかりました。完了すると `availability()` が `available` に変わります。
+
+そのうえで、同じ記事本文（約240文字）を要約させた結果がこちらです。
+
+| API | 処理 | 出力 | 時間 |
+|---|---|---|---|
+| Translator | 93文字を翻訳 | 48文字 | **44ms** |
+| Prompt API | 240文字を要約 | 129文字 | **1985ms** |
+
+出力1文字あたりに直すと、Translator が約0.35ms、Prompt API が約15msです。**40倍以上の差**があります。
+
+要約の品質自体は悪くありません。実際の出力です。
+
+```
+CSS Anchor Positioningは、CSSだけで要素を紐付けて配置する新しいレイアウト機構で、
+従来のJavaScriptライブラリの必要をなくします。全ブラウザで実装が完了し実戦投入が
+可能になった一方、APIの学習コストや満足度の低さが課題です。
+```
+
+読める日本語ですし、内容も入力に忠実です。ただ**2秒かかります**。そして Chrome には要約専用の Summarizer API が別に存在します。
+
+つまり、翻訳・要約・校正といった「タスクが決まっている処理」において、Prompt API を選ぶ理由は速度面では見当たりません。専用APIの方が速く、モデルのダウンロードも軽く、出力も安定します。
+
+## ハマりどころ
+
+実際に触って踏んだものをまとめます。
+
+### `LanguageModel.params()` は存在しない
+
+温度や topK のデフォルト値を取ろうとして呼ぶと落ちます。
+
+```
+TypeError: LanguageModel.params is not a function
+```
+
+そもそも `temperature` と `topK` は Chrome 拡張機能か origin trial 経由でのみ指定でき、通常のWebページからは触れません。パラメータ調整前提の設計はできないと考えた方が安全です。
+
+### モデルのダウンロードはユーザー操作が必須
+
+前述の通りです。自動テストやコンソールから叩こうとすると、ここで止まります。E2Eテストに組み込むなら、実際のクリックを発生させる必要があります。
+
+### `requestAnimationFrame` はバックグラウンドタブで止まる
+
+これは組み込みAIの話ではありませんが、計測ページを書くときに踏みました。rAF はタブが非アクティブだと発火しないので、自動計測するページでは `setTimeout` を併用しておかないと結果が空のままになります。
+
+```js
+let measured = false;
+function measure() {
+  if (measured) return;
+  measured = true;
+  // 計測処理
+}
+requestAnimationFrame(() => requestAnimationFrame(measure));
+setTimeout(measure, 300); // バックグラウンドタブ用の保険
+```
+
+## 標準化の状況は楽観できない
+
+速度以前の問題として、Prompt API はクロスブラウザ機能として設計できません。他エンジンが公式に反対を表明しています。
+
+- **Mozilla**: [standards-positions #1213](https://github.com/mozilla/standards-positions/issues/1213) に `position: negative` と `concerns: interoperability` のラベルが付いています（2025年4月28日起票）
+- **WebKit**: standards-positions の "ML Prompt API" に `position: oppose`、`concerns: interoperability` / `privacy` / `portability` のラベルが付いています（2025年5月14日起票）
+
+一方 Translator / LanguageDetector / Summarizer は[Chrome 138 で stable](https://developer.chrome.com/docs/ai/built-in-apis) になっていますが、これらも現時点では Chrome 独自です。いずれにせよフォールバック経路は必須になります。
+
+## 結論：APIの選び方
+
+実測から導かれる優先順位はシンプルです。
+
+1. **タスクが決まっているなら専用APIを使う。** 翻訳は Translator、言語判定は LanguageDetector、要約は Summarizer。速度が桁違いで、出力も安定します
+2. **言語判定は今すぐ使える。** モデルサイズが小さく `create()` 2ms・判定1msなので、フォールバックを書く手間の方が大きいくらいです
+3. **Prompt API は「専用APIがない、かつ出力が短い」タスクに限定する。** 分類・抽出のように出力を閉じられる用途でなければ、2秒待たされます
+4. **どれを使うにしてもフォールバックは必須。** Chrome 独自であることに加え、ハードウェア要件を満たさない端末では軒並み `unavailable` になります
+
+「ブラウザに LLM が載った」という切り口だと Prompt API に目が行きますが、**いま実務で効くのは地味な専用APIの方**でした。まずそちらから検討することをおすすめします。
+
+Prompt API を実際に使う場合の設計については、別記事「[Prompt APIを実用にする2つの条件——出力を閉じる、セッションを複製する](https://zenn.dev/ino_h/articles/2026-08-11-prompt-api-practical)」で条件を整理しています。
+
+## まとめ
+
+- Chrome 150 の実測で、LanguageDetector は `create()` 2ms・判定0〜1ms、Translator は90文字を26〜44msで処理した
+- 同じ生成処理で Prompt API は出力1文字あたり約15msかかり、Translator の40倍以上遅い
+- `Translator.availability()` は言語指定が必須、`LanguageModel.params()` は存在しない、Writer / Rewriter / Proofreader はグローバルすら生えていない
+- Prompt API のモデルダウンロードはユーザー操作必須
+- Mozilla は `position: negative`、WebKit は `position: oppose` を表明しており、クロスブラウザ前提には置けない

--- a/articles/2026-08-11-prompt-api-practical.md
+++ b/articles/2026-08-11-prompt-api-practical.md
@@ -1,0 +1,220 @@
+---
+title: "Prompt APIを実用にする2つの条件——出力を閉じる、セッションを複製する"
+emoji: "🧩"
+type: "tech"
+topics: ["chrome", "javascript", "ai", "gemini", "webapi"]
+published: true
+---
+
+## はじめに
+
+Chrome の Prompt API がWebページから使えるようになり、`LanguageModel.create()` でオンデバイスのモデルを呼べるようになりました。ただ「動かしてみた」記事は多い一方で、**何に使うと実用になるのか**の議論はあまり見かけません。
+
+Gemini Nano は小型モデルです。ChatGPT や Claude と同じ感覚で使うと、遅さと出力のブレに悩まされます。そこで手元の Chrome 150 でベンチマークを取り、実用になるタスクの形を絞り込みました。
+
+結論から書くと、条件は2つです。
+
+1. **`responseConstraint` で出力を閉じる**
+2. **`create()` ではなく `clone()` を使う**
+
+どちらも実測で効果を確認しました。順に見ていきます。
+
+## 前提：モデルの準備
+
+Prompt API は初回にモデルのダウンロードが必要です。`availability()` で状態を確認します。
+
+```js
+await LanguageModel.availability({});
+// 'available' | 'downloadable' | 'downloading' | 'unavailable'
+```
+
+`downloadable` が返った場合、ダウンロードは**ユーザー操作を起点にしないと開始できません**。DevTools のコンソールから叩いても始まらないので、ボタンのハンドラ内で呼ぶ必要があります。
+
+```html
+<button id="prep">モデルを準備する</button>
+<script>
+document.querySelector('#prep').addEventListener('click', async () => {
+  const session = await LanguageModel.create({
+    monitor(m) {
+      m.addEventListener('downloadprogress', (e) => {
+        console.log(`${(e.loaded * 100).toFixed(1)}%`);
+      });
+    },
+  });
+  session.destroy();
+});
+</script>
+```
+
+手元では数GB規模のダウンロードに数分かかりました。Chrome の[公式ドキュメント](https://developer.chrome.com/docs/ai/prompt-api)によると、空きストレージ22GB、GPUのVRAM 4GB以上またはCPU 16GB RAM以上・4コア以上が要件とされています。
+
+## 条件1：`responseConstraint` で出力を閉じる
+
+LLM の処理時間は出力トークン数にほぼ比例します。これを確かめるため、同じ入力（約240文字の技術記事）に対して**出力の長さだけを変えた3パターン**を各3回計測しました。
+
+### A. enum分類 — 出力を実質1トークンに
+
+記事の種別を2択で判定させます。`responseConstraint` に JSON Schema を渡すと、モデルの出力がスキーマに拘束されます。
+
+```js
+const SCHEMA_TYPE = { type: 'string', enum: ['tech', 'idea'] };
+
+const result = await session.prompt(
+  `次の記事は tech（技術解説）と idea（考察）のどちらですか。\n\n${text}`,
+  { responseConstraint: SCHEMA_TYPE }
+);
+console.log(JSON.parse(result)); // 'tech'
+```
+
+戻り値は**JSON文字列**なので `JSON.parse()` が必要です。ここは素の値が返ってくると勘違いしやすいポイントです。
+
+### B. 構造化抽出 — 配列を取る
+
+Zenn の `topics` 候補を出させます。
+
+```js
+const SCHEMA_TOPICS = {
+  type: 'object',
+  properties: {
+    topics: { type: 'array', items: { type: 'string' }, minItems: 3, maxItems: 5 },
+  },
+  required: ['topics'],
+  additionalProperties: false,
+};
+
+const result = await session.prompt(
+  `次の記事に付ける topics を3〜5個挙げてください。\n\n${text}`,
+  { responseConstraint: SCHEMA_TOPICS }
+);
+console.log(JSON.parse(result).topics);
+```
+
+### C. 自由生成 — 制約なし（対照群）
+
+```js
+const result = await session.prompt(`次の記事を日本語2文で要約してください。\n\n${text}`);
+```
+
+### 結果
+
+| ベンチ | 中央値 | 最小 | 最大 | 出力文字数 |
+|---|---:|---:|---:|---:|
+| A. enum分類 | **147ms** | 147 | 923 | 4 |
+| B. 構造化抽出 | **973ms** | 904 | 1146 | 73 |
+| C. 自由生成 | **1985ms** | 1888 | 2292 | 129 |
+
+**入力が同じでも、出力を短くするだけで13.5倍速くなりました。** 出力4文字→73文字→129文字に対して147ms→973ms→1985msと、ほぼ出力長に比例しています。
+
+A の最大値923msは初回のウォームアップです。2回目以降は147msに落ちるので、実運用では最初の1回を捨てるか、起動時に空打ちしておくと安定します。
+
+147msなら、入力欄の `blur` やフォーム送信の直前に挟んでもユーザーは待たされたと感じません。逆に2秒かかる自由生成をインタラクションの同期パスに置くのは無理があります。
+
+## 条件2：`create()` ではなく `clone()` を使う
+
+分類器のように同じシステムプロンプトで何度も呼ぶ場合、セッションの作り方でコストが変わります。`clone()` は初期プロンプトと対話履歴を引き継いだ複製を作ります。
+
+```js
+// テンプレートを1つだけ作る
+const base = await LanguageModel.create({
+  initialPrompts: [{
+    role: 'system',
+    content: 'あなたは日本語の技術記事を分類するアシスタントです。指示された値だけを返してください。',
+  }],
+});
+
+// リクエストごとに複製する
+const session = await base.clone();
+const result = await session.prompt(input, { responseConstraint: SCHEMA_TYPE });
+session.destroy();
+```
+
+計測結果です。
+
+| 処理 | 中央値 | 最小 | 最大 |
+|---|---:|---:|---:|
+| `create()`（system prompt付き） | 147ms | 147 | 164 |
+| `clone()` | **0ms** | 0 | 0 |
+
+`clone()` は**計測不能なほど速い**という結果でした。`create()` の147msは、システムプロンプトを毎回読み直すコストです。
+
+分類のたびに `create()` を呼ぶと、A の推論時間147msに対して同じだけのセッション構築コストが乗り、**単純に倍の時間**がかかります。テンプレートを1つ保持して複製する形にすれば、これはまるごと消えます。
+
+なお `clone()` は履歴も引き継ぐので、リクエスト間で文脈を分離したい場合はベースセッションに履歴を溜めないよう注意が必要です。使い終わったクローンは `destroy()` で捨てます。
+
+コンテキストの消費量は確認できます。
+
+```js
+console.log(`${session.contextUsage}/${session.contextWindow}`);
+```
+
+## 落とし穴：JSON Schema が保証するのは構造だけ
+
+ここが実務で一番刺さった点です。構造化抽出（B）を3回実行した結果を並べます。
+
+```
+1回目: ["css","layout","anchor positioning","web development","position-anchor"]
+2回目: ["css","layout","anchor-positioning","web development","browser compatibility"]
+3回目: ["css","layout","anchor-positioning","web-development"]
+```
+
+3回とも JSON としては正しく、スキーマにも適合しています。失敗はゼロです。しかし**値が毎回ぶれています**。
+
+- `anchor positioning` と `anchor-positioning` が混在
+- `web development` と `web-development` が混在
+- 3回目は4個しか返っていない（`minItems: 3` なので仕様上は正しい）
+
+つまり `responseConstraint` は「パースできる形で返ること」を保証しますが、「同じ値が返ること」は保証しません。タグ候補として使うなら、**既存タグ集合へのマッピング層が別途必要**になります。
+
+一方 enum分類（A）は3回とも `tech` で完全に一致しました。**選択肢を閉じきったときだけ、小型モデルの出力は信頼できます。** 自由文字列を含んだ瞬間に揺らぎが入る、と考えておくのが安全です。
+
+## では何に使うか
+
+以上を踏まえると、用途は3つに絞られます。
+
+### 1. enum分類
+
+問い合わせフォームのルーティング、通報の一次振り分け、コンテンツの種別判定。出力が閉じているので速く、安定します。147msなら同期的な処理に組み込めます。
+
+### 2. 構造化抽出
+
+自由記述から日付・金額・カテゴリを取り出す用途。ただし前述の通り値は揺れるので、後段でのバリデーションと正規化が前提です。
+
+### 3. 送信前チェック
+
+**ここが Prompt API でしかできない領域です。** 投稿前の本文に個人情報が混ざっていないか、攻撃的な表現になっていないかを、**サーバーに送る前に**判定する用途です。
+
+チェック対象のデータを外部に出せないことが要件なので、オンデバイスである必然性があります。逆に言うと、サーバーに送ってよいデータであれば、素直にサーバー側で高性能なモデルを呼んだ方が速くて確実です。
+
+### 使うべきでない用途
+
+翻訳・要約・校正には専用APIがあります。実測では Translator が90文字を26〜44msで処理したのに対し、Prompt API の自由生成は出力1文字あたり約15msでした。**専用APIがある領域で Prompt API を使う理由は速度面では見当たりません。**
+
+専用APIとの比較は別記事「[Chromeの組み込みAIを実測したら、速いのはLLMじゃない方だった](https://zenn.dev/ino_h/articles/2026-08-11-chrome-builtin-ai-benchmark)」に詳しくまとめています。
+
+## 標準化のリスクは織り込んでおく
+
+実装を検討するうえで無視できないのが、他エンジンの姿勢です。
+
+- **Mozilla**: [standards-positions #1213](https://github.com/mozilla/standards-positions/issues/1213) に `position: negative` と `concerns: interoperability` のラベル（2025年4月28日起票）
+- **WebKit**: standards-positions の "ML Prompt API" に `position: oppose`、`concerns: interoperability` / `privacy` / `portability` のラベル（2025年5月14日起票）
+
+相互運用性が争点になっているのは、API の性質上ある意味で当然です。プロンプトはモデルごとに最適化されるため、Gemini Nano で狙い通り動くプロンプトが、別のブラウザの別のモデルで同じ品質を返す保証がありません。CSS や DOM API のように「仕様通りに書けば同じ結果になる」という前提が成立しないのです。
+
+したがって Prompt API は、**現時点では Chrome 限定の拡張機能として設計する**べきです。必ずフォールバック経路を用意し、機能が無い環境でも成立するUIにしておく必要があります。
+
+```js
+if ('LanguageModel' in self && await LanguageModel.availability({}) === 'available') {
+  // オンデバイスで処理
+} else {
+  // サーバー側にフォールバック、または機能自体を出さない
+}
+```
+
+## まとめ
+
+- Prompt API の処理時間は出力長にほぼ比例する。実測で enum分類147ms、構造化抽出973ms、自由生成1985ms と13.5倍の差が出た
+- `responseConstraint` に JSON Schema を渡して出力を閉じるのが最大の高速化手段。戻り値は JSON 文字列なので `JSON.parse()` が必要
+- `create()` 147ms に対し `clone()` は0ms。同じシステムプロンプトを使い回すならテンプレートを複製する
+- JSON Schema は構造しか保証しない。自由文字列を含むと値は毎回ぶれる。enum で閉じたときだけ安定した
+- 本領は「送信前チェック」のようにデータを外に出せない用途。翻訳・要約は専用APIの方が速い
+- Mozilla・WebKit が公式に反対を表明しているため、Chrome 限定機能として設計しフォールバックを用意する


### PR DESCRIPTION
## 概要

Chrome 150 の実機で組み込みAI（Built-in AI APIs）を実測した記事を2本追加します。

| ファイル | タイトル | type |
|---|---|---|
| `articles/2026-08-11-chrome-builtin-ai-benchmark.md` | Chromeの組み込みAIを実測したら、速いのはLLMじゃない方だった | tech |
| `articles/2026-08-11-prompt-api-practical.md` | Prompt APIを実用にする2つの条件——出力を閉じる、セッションを複製する | tech |

分担は「どのAPIを選ぶか」（1本目）と「Prompt APIをどう使うか」（2本目）で、内容の重複は最小限にしています。相互にクロスリンクを張っています。

## 実測データ（すべて Chrome 150 / macOS、各3回）

**専用API**

- LanguageDetector: `create()` 2ms、判定 0〜1ms
- Translator: `create()` 109ms、90文字の翻訳 26〜44ms、ウォーム後の短文 8ms

**Prompt API（Gemini Nano）**

| ベンチ | 中央値 | 出力文字数 |
|---|---:|---:|
| enum分類 | 147ms | 4 |
| 構造化抽出 | 973ms | 73 |
| 自由生成 | 1985ms | 129 |
| `create()` | 147ms | — |
| `clone()` | 0ms | — |

## 一次ソース確認

- 標準化ポジションは GitHub API で実物のラベルを確認（Mozilla `position: negative` / WebKit `position: oppose`）。反対理由の文言は二次情報しか取れなかったため、引用せず自分の言葉で要約しています
- API 仕様・要件は developer.chrome.com を WebFetch で確認
- 記事内のレイテンシ・出力はすべて実機の計測値・実出力で、推定値は含みません

## 確認事項

- [ ] 内容の正確性
- [ ] リンク切れ
- [ ] frontmatter（title 35文字 / 40文字、いずれも上限70以内）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Chrome 150の組み込みAI APIについて、可用性・レイテンシ・利用例・出力例をまとめた記事を追加しました。
  * LanguageDetector、Translator、Prompt APIの機能検出、制約、モデル準備、フォールバック方法を解説しています。
  * Prompt APIの`responseConstraint`や`clone()`の活用、構造化出力・自由生成の比較、専用APIとの使い分けを紹介しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->